### PR TITLE
Implement average daily earnings

### DIFF
--- a/src/components/Status/index.tsx
+++ b/src/components/Status/index.tsx
@@ -10,7 +10,7 @@ import {
 } from '@chakra-ui/react'
 import BannerBox from '../Global/BannerBox'
 
-import { BOSS_TYPES } from '../../constants'
+import { BOSS_TYPES, roundRewards } from '../../contracts/raid'
 import { useState, useEffect } from 'react'
 import { useInterval } from '../../hooks/useInterval'
 import {
@@ -21,12 +21,14 @@ import {
   BossCrownMythic,
   BossCrownStrong,
 } from './BossCrowns'
+import { AVG_BLOCK_TIME, CFTI_DECIMALS } from '../../constants'
 
 type StatusProps = {
   bossTypeNum?: any
   bossHealth: any
   bossMaxHealth: any
   raidDmg: any
+  avgYield: any
   multiplier: any
   unclaimedBalance: any
   tokenBalance: any
@@ -43,19 +45,14 @@ const calculateCFTI = ({
   blocks: any
   multiplier: any
   DPB: any
-}) => {
-  if (blocks) {
-    return (blocks * multiplier * DPB) / 10 ** 18
-  } else {
-    return 0
-  }
-}
+}) => (blocks ? roundRewards(blocks, multiplier, DPB) / 10 ** CFTI_DECIMALS : 0)
 
 const Status = ({
   bossTypeNum,
   bossHealth,
   bossMaxHealth,
   raidDmg,
+  avgYield,
   multiplier,
   unclaimedBalance,
   tokenBalance,
@@ -64,7 +61,6 @@ const Status = ({
   usdToggled,
 }: StatusProps) => {
   const [counter, setCounter] = useState(0)
-  const avgBlockTime = 14
 
   useInterval(() => {
     if (counter > 0) {
@@ -73,11 +69,11 @@ const Status = ({
   }, 1000)
 
   useEffect(() => {
-    setCounter((bossHealth + 1) * avgBlockTime)
+    setCounter((bossHealth + 1) * AVG_BLOCK_TIME)
   }, [bossHealth])
 
   const bossPercent = () => {
-    return (bossHealth / bossMaxHealth) * 100
+    return (bossHealth / AVG_BLOCK_TIME) * 100
   }
 
   const bossPercentInverse = () => {
@@ -171,6 +167,19 @@ const Status = ({
             {timeLeft(counter)}
           </Text>
         </Text>
+        <div style={{ marginTop: '1em' }}>
+          <Text fontSize="md" fontWeight="bold" color={connected ? '' : 'gray'}>
+            Avg Daily Earnings:
+          </Text>
+          <Text color={connected ? '' : 'gray'}>
+            <Text as="span" fontSize="md" color={connected ? 'white' : 'gray'}>
+              {usdToggled
+                ? ((avgYield * usdPrice) / 10 ** CFTI_DECIMALS).toFixed(2)
+                : (avgYield / 10 ** CFTI_DECIMALS).toFixed(2)}
+            </Text>{' '}
+            {usdToggled ? 'USD' : 'CFTI'}
+          </Text>
+        </div>
       </Box>
       {connected && (
         <Flex justify="space-between">

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -7,14 +7,10 @@ export const TOKEN_ADDRESS = {
     "ETHUSD": '0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419'
 }
 
-export const BOSS_TYPES = [
-    "Basic",
-    "Strong",
-    "Epic",
-    "Mythic",
-    "Legendary",
-    "Godly"
-]
+// https://etherscan.io/chart/blocktime
+export const AVG_BLOCK_TIME = 13.5
+// https://etherscan.io/token/0xcfef8857e9c80e3440a823971420f7fa5f62f020
+export const CFTI_DECIMALS = 18
 
 export const TOKEN_ABI = [
     {

--- a/src/contracts/raid.ts
+++ b/src/contracts/raid.ts
@@ -1,0 +1,98 @@
+import { useCall } from '@usedapp/core'
+import { Contract } from '@ethersproject/contracts'
+import { TOKEN_ADDRESS, TOKEN_ABI, AVG_BLOCK_TIME } from '../constants'
+
+export const RAID_CONTRACT = new Contract(TOKEN_ADDRESS['RAID'], TOKEN_ABI)
+
+export const BOSS_TYPES = [
+  'Basic',
+  'Strong',
+  'Epic',
+  'Mythic',
+  'Legendary',
+  'Godly',
+]
+
+export type RaidBoss = {
+  weight: any
+  blockHealth: any
+  multiplier: any
+}
+
+// https://etherscan.io/address/0x3932deac6405edb53a3a020ef6e860f1536b412d#code#F10#L507
+export const roundRewards = (
+  blocks: number,
+  bossMultiplier: number,
+  dmgPerBlock: number
+) => blocks * dmgPerBlock * bossMultiplier
+
+export const useRaidBosses = (boss: number) => {
+  const { value, error } =
+    useCall({
+      contract: RAID_CONTRACT, // instance of called contract
+      method: 'bosses', // Method to be called
+      args: [boss || 0], // Method arguments
+    }) ?? {}
+  if (error) {
+    console.error(error.message)
+    return undefined
+  }
+  return value as unknown as RaidBoss
+}
+
+export const useExpectedYield = (dpb: number) => {
+  // We use a hard-coded constant so the number and the order of called hooks
+  // will also be constant
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const bosses = BOSS_TYPES.map((value, index) => useRaidBosses(index)).filter(
+    (boss) => boss
+  )
+  const totalWeight = bosses
+    .map((boss) => boss?.weight)
+    .reduce((acc, cur) => acc + cur, 0)
+
+  const expectedBlockEarnings = bosses
+    .map((boss) => {
+      const spawnChance = boss?.weight / totalWeight
+      const blockEarnings = dpb * boss?.multiplier
+      return spawnChance * blockEarnings
+    })
+    .reduce((prev, curr) => prev + curr, 0)
+
+  const secondsInDay = 60 * 60 * 24
+
+  return expectedBlockEarnings * (secondsInDay / AVG_BLOCK_TIME)
+}
+
+export const useRaidData = () => {
+  const { value, error } =
+    useCall({
+      contract: RAID_CONTRACT, // instance of called contract
+      method: 'getRaidData', // Method to be called
+      args: [], // Method arguments
+    }) ?? {}
+  if (error) {
+    console.error(error.message)
+    return 0
+  }
+
+  // console.log(value)
+  return value?.[0]
+}
+
+export const useUnclaimedCFTI = (address: string | null | undefined) => {
+  const { value, error } =
+    useCall(
+      address &&
+        TOKEN_ADDRESS['RAID'] && {
+          contract: RAID_CONTRACT, // instance of called contract
+          method: 'getPendingRewards', // Method to be called
+          args: [address], // Method arguments
+        }
+    ) ?? {}
+  if (error) {
+    console.error(error.message)
+    return undefined
+  }
+  return value?.[0]
+}


### PR DESCRIPTION
While implementing this I decided to factor out some raid-specific things to a separate file - I hope that the drive-by refactorings are okay. I also changed average block time to 13.5 to average between 13-14 that's more recent.

Overview: 

![image](https://user-images.githubusercontent.com/3093213/160036050-5dffee5a-445b-4039-b418-512888dff8b1.png)