### PR TITLE
Style buttons like in the live app version

### DIFF
--- a/src/styles/customTheme.ts
+++ b/src/styles/customTheme.ts
@@ -100,27 +100,24 @@ const customTheme = extendTheme({
             },
             variants: {
                 solid: {
-                    color: 'white',
-                    bg: '#7c41ea',
-                    boxShadow: '0 -3px 0 0 #703bd3, 0 3px 0 0 #4c2398, -3px 0 0 0 #6331c0, 3px 0 0 0 #6331c0, 0 0 0 3px #0f0c1b, 0 -6px 0 0 #0f0c1b, 0 6px 0 0 #0f0c1b, -6px 0 0 0 #0f0c1b, 6px 0 0 0 #0f0c1b',
+                    textColor: 'white',
+                    bg: "rgb(49 54 176)",
+                    boxShadow: '0 -2px 0 0 #474cc3, 0 2px 0 0 #22268e, -2px 0 0 0 #393eba, 2px 0 0 0 #393eba, 0 0 0 2px #0f0c1b, 0 -4px 0 0 #0f0c1b, 0 4px 0 0 #0f0c1b, -4px 0 0 0 #0f0c1b, 4px 0 0 0 #0f0c1b',
                     borderRadius: '1px',
                     _focus: {
-                        boxShadow: '0 -3px 0 0 #703bd3, 0 3px 0 0 #4c2398, -3px 0 0 0 #6331c0, 3px 0 0 0 #6331c0, 0 0 0 3px #0f0c1b, 0 -6px 0 0 #0f0c1b, 0 6px 0 0 #0f0c1b, -6px 0 0 0 #0f0c1b, 6px 0 0 0 #0f0c1b'
-                    },
-                    _active: {
-                        bg: '#7c41ea'
+                        boxShadow: '0 -2px 0 0 #474cc3, 0 2px 0 0 #22268e, -2px 0 0 0 #393eba, 2px 0 0 0 #393eba, 0 0 0 2px #0f0c1b, 0 -4px 0 0 #0f0c1b, 0 4px 0 0 #0f0c1b, -4px 0 0 0 #0f0c1b, 4px 0 0 0 #0f0c1b',
                     },
                     _hover: {
-                        bg: '#7c41ea',
-                        transform: 'scale(1.07)',
+                        bg: "rgb(49 54 176)",
+                        filter: "brightness(1.25)",
                         _disabled: {
-                            bg: '#7c41ea',
-                            transform: 'none'
+                            bg: "rgb(49 54 176)",
+                            filter: "brightness(1)",
                         }
                     },
                     _disabled: {
-                        opacity: 1,
-                        boxShadow: '0 -3px 0 0 #703bd3, 0 3px 0 0 #4c2398, -3px 0 0 0 #6331c0, 3px 0 0 0 #6331c0, 0 0 0 3px #0f0c1b, 0 -6px 0 0 #0f0c1b, 0 6px 0 0 #0f0c1b, -6px 0 0 0 #0f0c1b, 6px 0 0 0 #0f0c1b'
+                        opacity: 0.80,
+                        boxShadow: '0 -2px 0 0 #474cc3, 0 2px 0 0 #22268e, -2px 0 0 0 #393eba, 2px 0 0 0 #393eba, 0 0 0 2px #0f0c1b, 0 -4px 0 0 #0f0c1b, 0 4px 0 0 #0f0c1b, -4px 0 0 0 #0f0c1b, 4px 0 0 0 #0f0c1b',
                     }
                 }
             }

--- a/src/styles/customTheme.ts
+++ b/src/styles/customTheme.ts
@@ -107,6 +107,11 @@ const customTheme = extendTheme({
                     _focus: {
                         boxShadow: '0 -2px 0 0 #474cc3, 0 2px 0 0 #22268e, -2px 0 0 0 #393eba, 2px 0 0 0 #393eba, 0 0 0 2px #0f0c1b, 0 -4px 0 0 #0f0c1b, 0 4px 0 0 #0f0c1b, -4px 0 0 0 #0f0c1b, 4px 0 0 0 #0f0c1b',
                     },
+                    _active: {
+                        bg: "rgb(49 54 176)",
+                        filter: "brightness(1.5)",
+                        boxShadow: '0 -2px 0 0 #474cc3, 0 2px 0 0 #22268e, -2px 0 0 0 #393eba, 2px 0 0 0 #393eba, 0 0 0 2px #0f0c1b, 0 -4px 0 0 #0f0c1b, 0 4px 0 0 #0f0c1b, -4px 0 0 0 #0f0c1b, 4px 0 0 0 #0f0c1b',
+                    },
                     _hover: {
                         bg: "rgb(49 54 176)",
                         filter: "brightness(1.25)",


### PR DESCRIPTION
Adapts the current button to use the same styling as in the app, see below:

app.raid.party
![image](https://user-images.githubusercontent.com/3093213/161575625-372bd62f-7517-41df-8cbd-7d36b7f70483.png)
Before
![image](https://user-images.githubusercontent.com/3093213/161575704-3bb668d4-eb56-46e1-a551-c2011078fc79.png)
After
![image](https://user-images.githubusercontent.com/3093213/161575775-a1c28309-05c9-401f-ad6c-9998426e3723.png)
